### PR TITLE
Better implementation of SparseArray.

### DIFF
--- a/src/main/scala/software/uncharted/salt/core/generation/output/SeriesData.scala
+++ b/src/main/scala/software/uncharted/salt/core/generation/output/SeriesData.scala
@@ -83,9 +83,12 @@ class SeriesData[
     val newBins = SparseArray.merge(binMerge)(this.bins, that.bins)
 
     // compute new meta
-    var newMeta: Option[NX] = None
-    if  (tileMetaMerge.isDefined && this.tileMeta.isDefined && that.tileMeta.isDefined) {
-      newMeta = Some(tileMetaMerge.get(this.tileMeta.get, that.tileMeta.get))
+    val newMeta: Option[NX] = for (
+      mergeFcn <- tileMetaMerge;
+      thisMeta <- this.tileMeta;
+      thatMeta <- that.tileMeta
+    ) yield {
+      mergeFcn(thisMeta, thatMeta)
     }
 
     new SeriesData(projection, maxBin, coords, newBins, newMeta)

--- a/src/main/scala/software/uncharted/salt/core/generation/rdd/RDDTileGenerator.scala
+++ b/src/main/scala/software/uncharted/salt/core/generation/rdd/RDDTileGenerator.scala
@@ -272,7 +272,7 @@ private class RDDSeriesWrapper[
 
     series.tileAggregator.foreach { aggregator =>
       for (i <- finishedBins.indices) {
-        aggregator.add(tile, Some(finishedBins(i)))
+        tile = aggregator.add(tile, Some(finishedBins(i)))
       }
     }
 

--- a/src/main/scala/software/uncharted/salt/core/generation/rdd/RDDTileGenerator.scala
+++ b/src/main/scala/software/uncharted/salt/core/generation/rdd/RDDTileGenerator.scala
@@ -267,17 +267,14 @@ private class RDDSeriesWrapper[
     }
     val key = binData._1
 
-    var finishedBins = new SparseArray[V](0, series.binAggregator.finish(series.binAggregator.default))
     val typedBinData = binData._2.asInstanceOf[SparseArray[U]]
-    while (finishedBins.length < typedBinData.length) {
-      val a = typedBinData(finishedBins.length)
-      val bin = series.binAggregator.finish(a)
-      if (series.tileAggregator.isDefined) {
-        tile = series.tileAggregator.get.add(tile, Some(bin))
+    val finishedBins = typedBinData.map(series.binAggregator.finish(_))
+
+    series.tileAggregator.foreach { aggregator =>
+      for (i <- finishedBins.indices) {
+        aggregator.add(tile, Some(finishedBins(i)))
       }
-      finishedBins += bin
     }
-    finishedBins = finishedBins.result()
 
     val finishedTile: Option[X] = series.tileAggregator match {
       case None => None

--- a/src/main/scala/software/uncharted/salt/core/projection/Projection.scala
+++ b/src/main/scala/software/uncharted/salt/core/projection/Projection.scala
@@ -43,4 +43,12 @@ abstract class Projection[DC, TC, BC]() extends Serializable {
    * @return the bin index converted into its one-dimensional representation
    */
   def binTo1D(bin: BC, maxBin: BC): Int
+
+  /**
+    * Project a 1 dimensional index into a bin index for easy retrieval of bin values from an array
+    * @param index An array index
+    * @param maxBin The maximum possible bin index (i.e. if your tile is 256x256, this would be (255, 255))
+    * @return The bin index indicated by this one dimensional representation
+    */
+  def binFrom1D (index: Int, maxBin: BC): BC
 }

--- a/src/main/scala/software/uncharted/salt/core/projection/numeric/CartesianProjection.scala
+++ b/src/main/scala/software/uncharted/salt/core/projection/numeric/CartesianProjection.scala
@@ -65,4 +65,10 @@ class CartesianProjection(
   override def binTo1D(bin: (Int, Int), maxBin: (Int, Int)): Int = {
     bin._1 + bin._2*(maxBin._1 + 1)
   }
+  override def binFrom1D(index: Int, maxBin: (Int, Int)): (Int, Int) = {
+    val bins = maxBin._1 + 1
+
+    val x = index % bins
+    (x, (index - x) / bins)
+  }
 }

--- a/src/main/scala/software/uncharted/salt/core/projection/numeric/MercatorProjection.scala
+++ b/src/main/scala/software/uncharted/salt/core/projection/numeric/MercatorProjection.scala
@@ -73,4 +73,11 @@ class MercatorProjection(
   override def binTo1D(bin: (Int, Int), maxBin: (Int, Int)): Int = {
     bin._1 + bin._2*(maxBin._1 + 1)
   }
+
+  override def binFrom1D (index: Int, maxBin: (Int, Int)): (Int, Int) = {
+    val bins = maxBin._1 + 1
+
+    val x = index % bins
+    (x, (index - x) / bins)
+  }
 }

--- a/src/main/scala/software/uncharted/salt/core/projection/numeric/SeriesProjection.scala
+++ b/src/main/scala/software/uncharted/salt/core/projection/numeric/SeriesProjection.scala
@@ -58,4 +58,8 @@ class SeriesProjection(
   override def binTo1D(bin: Int, maxBin: Int): Int = {
     bin
   }
+
+  override def binFrom1D(index: Int, maxBin: Int): Int = {
+    index
+  }
 }

--- a/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
+++ b/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
@@ -31,23 +31,15 @@ import scala.reflect.ClassTag
   * Automatically materializes into a dense array when the number of non-default
   * values stored exceeds some threshold.
   *
-  * Note that this is <em>not</em> a standard scala sequence.  While the map
-  * method has basically the same meaning, the reduce method <em>only</em> has
-  * the same meaning if the default value passed into the sparse array is a zero,
-  * because reduce only operates on non-defaulted entries.  Also not that this
-  * means that, if given a non-zero default value, reduce will return different
-  * values if an array is materialized and if it is not.  In general, it is
-  * clearly best to use a default value equivalent to zero with respect to any
-  * operations that will be performed on the data.
+  * Note that this is <em>not</em> a standard scala sequence.  Use the .seq
+  * method to obtain an equivalent that is, if needed.
   *
   * Probably not thread-safe due to lack of locking on materialization.
   *
   * TODO: https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/locks/ReadWriteLock.html
   *
   * @param _length The (fixed) length of the array
-  * @param _default The default value used for elements without a specifically set value.  This value should always
-  *                 be a zero with respect to the operations to be performed on the sparse array.  If it is not, the
-  *                 above warnings about non-standard behavior in the reduce function will come into play.
+  * @param _default The default value used for elements without a specifically set value.
   * @param _threshold The proportion of elements with non-default values beyond which the array will be materialized
   * @tparam T the type of value being stored in the SparseArray
   */
@@ -180,20 +172,6 @@ class SparseArray[@specialized(Int, Long, Double) T: ClassTag] (_length: Int, _d
       }
     }
     result
-  }
-
-  /** Aggregate the non-defaulted values in this SparseArray
-    *
-    * Note there is a slight difference between how reduce runs in SparseArrays and in other sequences, in the the
-    * reduction function is <em>only</em> run on non-defaulted values.  If running on defaulted values is desired,
-    * please use seq.reduce.
-    *
-    * @param fcn A function that takes two values and combines them into one
-    * @tparam U The reduced output type
-    * @return The reduced value of all non-default entries in the SparseArray
-    */
-  def reduce[U >: T] (fcn: (U, U) => U): U = {
-    denseStorage.map(_.reduce(fcn)).getOrElse(sparseStorage.values.reduce(fcn))
   }
 
   /** Transform this SparseArray into a normal scala Seq.  This returns a materialized form of the SparseArray, but

--- a/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
+++ b/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
@@ -36,7 +36,8 @@ import scala.reflect.ClassTag
   * @param _threshold The proportion of elements with non-default values beyond which the array will be materialized
   * @tparam T the type of value being stored in the SparseArray
   */
-class SparseArray[@specialized(Int, Long, Double) T: ClassTag] (_length: Int, _default: T, _threshold: Float = 1/3F) {
+class SparseArray[@specialized(Int, Long, Double) T: ClassTag] (_length: Int, _default: T, _threshold: Float = 1/3F
+                                                               ) extends Serializable {
   private val sparseStorage = mutable.Map[Int, T]()
   private var denseStorage: Option[Array[T]] = None
 

--- a/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
+++ b/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
@@ -106,7 +106,7 @@ class SparseArray[@specialized(Int, Long, Double) T: ClassTag] (_length: Int, _d
   /** The proportion of possible elements having a non-default value beyond which the SparseArray will be
     * materialized
     */
-  private def materializationThreshold = _threshold
+  private[util] def materializationThreshold = _threshold
 
   /** Determine the density this array would have, if not materialized, and with the given number of elements having
     * non-default values.

--- a/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
+++ b/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
@@ -85,7 +85,7 @@ class SparseArray[@specialized(Int, Long, Double) T: ClassTag] (_length: Int, _d
   /** The (fixed) length of the sparse array */
   def length (): Int = _length
   /** The range of indices of the sparse array */
-  def indices = Range(0, _length)
+  def indices: Range = Range(0, _length)
   /** The default value of the sparse array */
   def default (): T = _default
 

--- a/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
+++ b/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
@@ -148,6 +148,11 @@ class SparseArray[@specialized(Int, Long, Double) T: ClassTag] (_length: Int, _d
     result
   }
 
+  /** Shorthand accessor for the first element of the array
+    * @return The head element
+    */
+  def head: T = this(0)
+
   /** Transform this SparseArray according to the input function.
     *
     * Unlike map, the input function here is given the index of the element.

--- a/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
+++ b/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
@@ -25,14 +25,29 @@ import scala.reflect.ClassTag
 
 /**
   * An integer-indexed sparse array implementation, currently based on HashMap.
+  *
   * Specialized for storing Ints, Longs and Doubles
+  *
   * Automatically materializes into a dense array when the number of non-default
   * values stored exceeds some threshold.
+  *
+  * Note that this is <em>not</em> a standard scala sequence.  While the map
+  * method has basically the same meaning, the reduce method <em>only</em> has
+  * the same meaning if the default value passed into the sparse array is a zero,
+  * because reduce only operates on non-defaulted entries.  Also not that this
+  * means that, if given a non-zero default value, reduce will return different
+  * values if an array is materialized and if it is not.  In general, it is
+  * clearly best to use a default value equivalent to zero with respect to any
+  * operations that will be performed on the data.
+  *
   * Probably not thread-safe due to lack of locking on materialization.
+  *
   * TODO: https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/locks/ReadWriteLock.html
   *
   * @param _length The (fixed) length of the array
-  * @param _default The default value used for elements without a specifically set value
+  * @param _default The default value used for elements without a specifically set value.  This value should always
+  *                 be a zero with respect to the operations to be performed on the sparse array.  If it is not, the
+  *                 above warnings about non-standard behavior in the reduce function will come into play.
   * @param _threshold The proportion of elements with non-default values beyond which the array will be materialized
   * @tparam T the type of value being stored in the SparseArray
   */

--- a/src/test/scala/software/uncharted/salt/core/generation/output/SeriesDataSpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/generation/output/SeriesDataSpec.scala
@@ -27,7 +27,7 @@ class SeriesDataSpec extends FunSpec {
 
     describe("#apply()") {
       it("should access the given bin using a bin coordinate, returning the appropriate value") {
-        val bins = new SparseArray(2, 0, Map(1 -> 12))
+        val bins = SparseArray(2, 0)(1 -> 12)
         val data = new SeriesData(projection, 1, (0, 0), bins, None)
         assert(data(0) == bins(0))
         assert(data(1) == bins(1))
@@ -36,10 +36,10 @@ class SeriesDataSpec extends FunSpec {
 
     describe("#merge()") {
       it("should allow clients to merge bins from two compatible SeriesData objects") {
-        val bins = new SparseArray(2, 0, Map(1 -> 12))
+        val bins = SparseArray(2, 0)(1 -> 12)
         val data = new SeriesData(projection, 1, (0, 0), bins, Some("hello"))
 
-        val otherBins = new SparseArray(2, 4, Map(1 -> 6))
+        val otherBins = SparseArray(2, 4)(1 -> 6)
         val otherData = new SeriesData(projection, 1, (0, 0), otherBins, Some("world"))
 
         val result = data.merge(otherData, (l: Int, r: Int) => l+r)
@@ -50,10 +50,10 @@ class SeriesDataSpec extends FunSpec {
       }
 
       it("should allow clients to merge tile metadata from two compatible SeriesData objects") {
-        val bins = new SparseArray(2, 0, Map(1 -> 12))
+        val bins = SparseArray(2, 0)(1 -> 12)
         val data = new SeriesData(projection, 1, (0, 0), bins, Some("hello"))
 
-        val otherBins = new SparseArray(2, 4, Map(1 -> 6))
+        val otherBins = SparseArray(2, 4)(1 -> 6)
         val otherData = new SeriesData(projection, 1, (0, 0), otherBins, Some("world"))
 
         val result = data.merge(
@@ -72,10 +72,10 @@ class SeriesDataSpec extends FunSpec {
       }
 
       it("should throw a SeriesDataMergeException if the two SeriesData objects have differing numbers of bins") {
-        val bins = new SparseArray(2, 0, Map(1 -> 12))
+        val bins = SparseArray(2, 0)(1 -> 12)
         val data = new SeriesData(projection, 1, (0, 0), bins, None)
 
-        val otherBins = new SparseArray(3, 4, Map(1 -> 6))
+        val otherBins = SparseArray(3, 4)(1 -> 6)
         val otherData = new SeriesData(projection, 2, (0, 0), otherBins, None)
 
         intercept[SeriesDataMergeException] {
@@ -84,10 +84,10 @@ class SeriesDataSpec extends FunSpec {
       }
 
       it("should throw a SeriesDataMergeException if the two SeriesData objects have different tile coordinates") {
-        val bins = new SparseArray(2, 0, Map(1 -> 12))
+        val bins = SparseArray(2, 0)(1 -> 12)
         val data = new SeriesData(projection, 1, (0, 0), bins, None)
 
-        val otherBins = new SparseArray(2, 4, Map(1 -> 6))
+        val otherBins = SparseArray(2, 4)(1 -> 6)
         val otherData = new SeriesData(projection, 1, (1, 0), otherBins, None)
 
         intercept[SeriesDataMergeException] {

--- a/src/test/scala/software/uncharted/salt/core/generation/rdd/RDDTileGeneratorSpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/generation/rdd/RDDTileGeneratorSpec.scala
@@ -96,8 +96,8 @@ class RDDTileGeneratorSpec extends FunSpec {
         assert(result(0).bins(1) === manualBins.get(true).getOrElse(0))
 
         //verify max/min tile analytic
-        val min = result(0).bins.reduce((a,b) => Math.min(a, b))
-        val max = result(0).bins.reduce((a,b) => Math.max(a, b))
+        val min = result(0).bins.seq.reduce((a,b) => Math.min(a, b))
+        val max = result(0).bins.seq.reduce((a,b) => Math.max(a, b))
         assert(result(0).tileMeta.isDefined)
         assert(result(0).tileMeta.get._1 === min)
         assert(result(0).tileMeta.get._2 === max)
@@ -157,8 +157,8 @@ class RDDTileGeneratorSpec extends FunSpec {
         assert(result(0).bins(1) === manualBins.get(true).getOrElse(0))
 
         //verify max/min tile analytic
-        val min = result(0).bins.reduce((a,b) => Math.min(a, b))
-        val max = result(0).bins.reduce((a,b) => Math.max(a, b))
+        val min = result(0).bins.seq.reduce((a,b) => Math.min(a, b))
+        val max = result(0).bins.seq.reduce((a,b) => Math.max(a, b))
         assert(result(0).tileMeta.isDefined)
         assert(result(0).tileMeta.get._1 === min)
         assert(result(0).tileMeta.get._2 === max)
@@ -281,8 +281,8 @@ class RDDTileGeneratorSpec extends FunSpec {
         assert(result(0).bins(1) === manualBins.get(true).getOrElse(0))
 
         //verify max/min tile analytic
-        val min = result(0).bins.reduce((a,b) => Math.min(a, b))
-        val max = result(0).bins.reduce((a,b) => Math.max(a, b))
+        val min = result(0).bins.seq.reduce((a,b) => Math.min(a, b))
+        val max = result(0).bins.seq.reduce((a,b) => Math.max(a, b))
         assert(result(0).tileMeta.isDefined)
         assert(result(0).tileMeta.get._1 === min)
         assert(result(0).tileMeta.get._2 === max)

--- a/src/test/scala/software/uncharted/salt/core/projection/numeric/CartesianProjectionSpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/projection/numeric/CartesianProjectionSpec.scala
@@ -124,5 +124,18 @@ class CartesianProjectionSpec extends FunSpec {
         }
       }
     }
+
+    describe("#binFrom1D()") {
+      it("should convert an index to a 2D bin coordinate, assuming row-major order") {
+        val projection = new CartesianProjection(Seq(0), (0D, 0D), (1D, 1D))
+
+        // fuzz inputs
+        for (i <- 0 until 100) {
+          val bin = (Math.round(Math.random*99).toInt, Math.round(Math.random*99).toInt)
+          val index = bin._1 + 100 * bin._2
+          assert(bin === projection.binFrom1D(index, (99, 99)))
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/software/uncharted/salt/core/projection/numeric/MercatorProjectionSpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/projection/numeric/MercatorProjectionSpec.scala
@@ -17,8 +17,6 @@
 package software.uncharted.salt.core.projection.numeric
 
 import org.scalatest._
-import software.uncharted.salt.core.projection._
-import org.apache.spark.sql.Row
 
 class MercatorProjectionSpec extends FunSpec {
   describe("MercatorProjection") {
@@ -156,6 +154,19 @@ class MercatorProjectionSpec extends FunSpec {
           val unidim = projection.binTo1D(bin, (99,99))
           assert(unidim <= 100*100)
           assert(unidim === bin._1 + bin._2*100)
+        }
+      }
+    }
+
+    describe("#binFrom1D()") {
+      it("should convert an index to a 2D bin coordinate, assuming row-major order") {
+        val projection = new MercatorProjection(Seq(0), (-180D, -85D), (180D, 85D))
+
+        // fuzz inputs
+        for (i <- 0 until 100) {
+          val bin = (Math.round(Math.random*99).toInt, Math.round(Math.random*99).toInt)
+          val index = bin._1 + 100 * bin._2
+          assert(bin === projection.binFrom1D(index, (99, 99)))
         }
       }
     }

--- a/src/test/scala/software/uncharted/salt/core/projection/numeric/SeriesProjectionSpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/projection/numeric/SeriesProjectionSpec.scala
@@ -94,5 +94,16 @@ class SeriesProjectionSpec extends FunSpec {
         }
       }
     }
+
+    describe("#binFrom1D()") {
+      it("should be a no-op, returning the index passed in") {
+        val projection = new SeriesProjection(Seq(0), 0D, 1D)
+        //fuzz inputs
+        for (i <- 0 until 100) {
+          val bin = Math.round(Math.random*99).toInt
+          assert(projection.binFrom1D(bin, 99) === bin)
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
@@ -290,5 +290,17 @@ class SparseArraySpec extends FunSpec {
         assert(seq.toList === List(1, 0, 4))
       }
     }
+
+    describe("#head") {
+      it("should return the default when element 0 isn't set") {
+        val sa = SparseArray(3, 0, 0.0f)(1 -> 1, 2 -> 4)
+        assert(0 === sa.head)
+      }
+
+      it("should return the explicitly set value of element 0 when appropriate") {
+        val sa = SparseArray(3, 0, 0.0f)(0 -> 1, 2 -> 4)
+        assert(1 === sa.head)
+      }
+    }
   }
 }

--- a/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
@@ -21,16 +21,36 @@ import org.scalatest._
 class SparseArraySpec extends FunSpec {
   describe("SparseArray") {
     describe("#apply()") {
-      it("should return the element at the given index") {
-        val test = new SparseArray(2, -1, Map(0 -> 12))
-        assert(test(0) == 12)
+      it("should return the element at the given index if materialized") {
+        val test = SparseArray(2, -1, 0.0f)(0 -> 12)
+        assert(test.isMaterialized)
+        assert(test(0) === 12)
       }
-      it("should return the default element if there is no value set at the given index") {
-        val test = new SparseArray(2, -1, Map(0 -> 12))
-        assert(test(1) == -1)
+      it("should return the default element if there is no value set at the given index if materialized") {
+        val test = SparseArray(2, -1, 0.0f)(0 -> 12)
+        assert(test.isMaterialized)
+        assert(test(1) === -1)
       }
-      it("should throw an ArrayOutOfBoundsException if the given index is outside the SparseArray size") {
-        val test = new SparseArray(2, -1, Map())
+      it("should throw an ArrayOutOfBoundsException if the given index is outside the SparseArray size if materialized") {
+        val test = SparseArray(2, -1, 0.0f)(0 -> 12)
+        assert(test.isMaterialized)
+        intercept[ArrayIndexOutOfBoundsException] {
+          test(2)
+        }
+      }
+      it("should return the element at the given index if not materialized") {
+        val test = SparseArray(2, -1, 1.0f)(0 -> 12)
+        assert(!test.isMaterialized)
+        assert(test(0) === 12)
+      }
+      it("should return the default element if there is no value set at the given index if not materialized") {
+        val test = SparseArray(2, -1, 1.0f)(0 -> 12)
+        assert(!test.isMaterialized)
+        assert(test(1) === -1)
+      }
+      it("should throw an ArrayOutOfBoundsException if the given index is outside the SparseArray size if not materialized") {
+        val test = SparseArray(2, -1, 1.0f)(0 -> 12)
+        assert(!test.isMaterialized)
         intercept[ArrayIndexOutOfBoundsException] {
           test(2)
         }
@@ -39,47 +59,54 @@ class SparseArraySpec extends FunSpec {
 
     describe("#length()") {
       it("should return the size of the SparseArray") {
-        val test = new SparseArray(2, -1, Map())
-        assert(test.length() == 2)
+        val test = SparseArray(2, -1)()
+        assert(test.length() === 2)
       }
     }
 
     describe("#density()") {
       it("should return the density of the SparseArray") {
-        val test = new SparseArray(2, -1, Map(), 1)
-        assert(test.length() == 2)
-        assert(test.density() == 0)
-        test.update(0, -1)
-        assert(test.density() == 0)
-        test.update(1, 2)
-        assert(test.density() == 0.5)
+        val test = SparseArray(2, -1, 1.0f)()
+        assert(test.length() === 2)
+        assert(test.density() === 0.0f)
+        test(0) = -1
+        assert(test.density() === 0.0f)
+        test(1) = 2
+        assert(test.density() === 0.5f)
+      }
+
+      it("should not cause materialization even at maximum density when the materialization threshold is set to 1.0") {
+        val test = SparseArray(2, -1, 1.0f)(0 -> 3, 1 -> 2)
+        assert(!test.isMaterialized)
       }
     }
 
     describe("#update()") {
       it("should set the element at the given index if the given index never had a value") {
-        val test = new SparseArray(2, -1, Map())
-        test.update(0, 12)
-        assert(test(0) == 12)
+        val test = SparseArray(2, -1)()
+        test(0) = 12
+        assert(test(0) === 12)
       }
 
       it("should set the element at the given index if the given index was already set") {
-        val test = new SparseArray(2, -1, Map(0 -> 0))
-        test.update(0, 12)
-        assert(test(0) == 12)
+        val test = SparseArray(2, -1)(0 -> 0)
+        test(0) = 12
+        assert(test(0) === 12)
       }
 
       it("should safely set the element at the given index to the default value, eliminating an existing stored value if one was present") {
-        val test = new SparseArray(5, -1, Map(0 -> 0))
-        test.update(0, 12)
-        test.update(0, -1)
-        test.update(1, -1)
-        assert(test(0) == -1)
-        assert(test(1) == -1)
+        val test = SparseArray(5, -1)(0 -> 0)
+        test(0) = 12
+        assert(test(0) === 12)
+        test(0) = -1
+        test(1) = -1
+        assert(test(0) === -1)
+        assert(test(1) === -1)
+        assert(test.density() === 0.0f)
       }
 
       it("should throw an ArrayOutOfBoundsException if the given index is outside the SparseArray size") {
-        val test = new SparseArray(2, -1, Map())
+        val test = SparseArray(2, -1)()
         intercept[ArrayIndexOutOfBoundsException] {
           test.update(2, 12)
         }
@@ -88,53 +115,53 @@ class SparseArraySpec extends FunSpec {
 
     describe("#seq()") {
       it("should convert the SparseArray to an IndexedSeq") {
-        val test = new SparseArray(2, -1, Map(0 -> 0))
+        val test = SparseArray(2, -1)(0 -> 0)
         val seq = test.seq
         assert(seq.isInstanceOf[scala.collection.IndexedSeq[Int]])
-        assert(seq.length == test.length)
+        assert(seq.length === test.length)
       }
     }
 
     describe("Builder") {
-      val test = new SparseArray(2, -1, Map(0 -> 0))
-      describe("#newBuilder()") {
-        it("should return a new, empty SparseArray with the same default value") {
-          val b = test.newBuilder()
-          assert(b.result.size == 0)
-          assert(b.result.default == test.default)
-        }
-      }
-      describe("#+=()") {
-        it("should append an element to the SparseArray builder") {
-          val b = test.newBuilder()
-          b += 12
-          assert(b.result.size == 1)
-          assert(b.result()(0) == 12)
-        }
-        it("should safely append a default element to the SparseArray builder") {
-          val b = test.newBuilder()
-          b += -1
-          assert(b.result.size == 1)
-          assert(b.result()(0) == -1)
-        }
-      }
-      describe("#clear()") {
-        it("should clear the SparseArray builder") {
-          val b = test.newBuilder()
-          b += 12
-          b.clear()
-          assert(b.result.size == 0)
-        }
-      }
-      describe("#result()") {
-        it("should convert the SparseArray builder into a SparseArray") {
-          val b = test.newBuilder()
-          b += 12
-          assert(b.result().isInstanceOf[SparseArray[Int]])
-          assert(b.result().length() == 1)
-          assert(b.result()(0) == 12)
-        }
-      }
+      val test = SparseArray(2, -1)(0 -> 0)
+//      describe("#newBuilder()") {
+//        it("should return a new, empty SparseArray with the same default value") {
+//          val b = test.newBuilder()
+//          assert(b.result.size == 0)
+//          assert(b.result.default == test.default)
+//        }
+//      }
+//      describe("#+=()") {
+//        it("should append an element to the SparseArray builder") {
+//          val b = test.newBuilder()
+//          b += 12
+//          assert(b.result.size == 1)
+//          assert(b.result()(0) == 12)
+//        }
+//        it("should safely append a default element to the SparseArray builder") {
+//          val b = test.newBuilder()
+//          b += -1
+//          assert(b.result.size == 1)
+//          assert(b.result()(0) == -1)
+//        }
+//      }
+//      describe("#clear()") {
+//        it("should clear the SparseArray builder") {
+//          val b = test.newBuilder()
+//          b += 12
+//          b.clear()
+//          assert(b.result.size == 0)
+//        }
+//      }
+//      describe("#result()") {
+//        it("should convert the SparseArray builder into a SparseArray") {
+//          val b = test.newBuilder()
+//          b += 12
+//          assert(b.result().isInstanceOf[SparseArray[Int]])
+//          assert(b.result().length() == 1)
+//          assert(b.result()(0) == 12)
+//        }
+//      }
     }
   }
 }

--- a/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
@@ -16,6 +16,7 @@
 
 package software.uncharted.salt.core.util
 
+import scala.collection.mutable.Buffer
 import org.scalatest._
 
 class SparseArraySpec extends FunSpec {
@@ -245,6 +246,32 @@ class SparseArraySpec extends FunSpec {
         assert(b(1) === -1)
         assert(b(2) === 18)
         assert(b.default() === -1)
+      }
+    }
+
+    describe("#default") {
+      it("should not change when its type is mutable and it is used as a basis for non-default values") {
+        val sa = SparseArray(3, Buffer[Int]())()
+        sa(0) = sa(0) += 2
+        sa(1) = sa(1) += 3
+        assert(List(2) === sa(0).toList)
+        assert(List(3) === sa(1).toList)
+        assert(List[Int]() === sa(2).toList)
+      }
+      it("should not change when its type is mutable, etc, even after being mapped.") {
+        val sa = SparseArray(4, Buffer[Int]())()
+        sa(0) = sa(0) += 2
+        val sa2 = sa.map(_.map(n => n*n))
+        sa2(1) = sa2(1) += 3
+        sa2(2) = sa2(2) += 5
+        assert(List(2) === sa(0).toList)
+        assert(List[Int]() === sa(1).toList)
+        assert(List[Int]() === sa(2).toList)
+        assert(List[Int]() === sa(3).toList)
+        assert(List(4) === sa2(0).toList)
+        assert(List(3) === sa2(1).toList)
+        assert(List(5) === sa2(2).toList)
+        assert(List[Int]() === sa2(3).toList)
       }
     }
 

--- a/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
@@ -206,6 +206,7 @@ class SparseArraySpec extends FunSpec {
         assert(b(0) === 1)
         assert(b(1) === 0)
         assert(b(2) === 16)
+        assert(b.default() === 0)
       }
 
       it("Should work fine on a sparse array") {
@@ -217,6 +218,33 @@ class SparseArraySpec extends FunSpec {
         assert(b(0) === 1)
         assert(b(1) === 0)
         assert(b(2) === 16)
+        assert(b.default() === 0)
+      }
+    }
+
+    describe("#mapWithIndex") {
+      it("Should work fine on a dense array") {
+        val a = SparseArray(3, 0, 0.0f)(0 -> 1, 2 -> 4)
+        val b = a.mapWithIndex((n, i) => n*n + i)
+        assert(b.isMaterialized)
+        assert(b.density() === 1.0f)
+        assert(b.materializationThreshold === 0.0f)
+        assert(b(0) === 1)
+        assert(b(1) === 1)
+        assert(b(2) === 18)
+        assert(b.default() === -1)
+      }
+
+      it("Should work fine on a sparse array") {
+        val a = SparseArray(3, 0, 1.0f)(0 -> 1, 2 -> 4)
+        val b = a.mapWithIndex((n, i) => n*n + i)
+        assert(!b.isMaterialized)
+        assert(b.density === 2/3f)
+        assert(b.materializationThreshold === 1.0f)
+        assert(b(0) === 1)
+        assert(b(1) === -1)
+        assert(b(2) === 18)
+        assert(b.default() === -1)
       }
     }
 

--- a/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
@@ -20,6 +20,10 @@ import org.scalatest._
 
 class SparseArraySpec extends FunSpec {
   describe("SparseArray") {
+    it("Should be serializable") {
+      assert(classOf[Serializable].isAssignableFrom(classOf[SparseArray[_]]))
+    }
+
     describe("#apply()") {
       it("should return the element at the given index if materialized") {
         val test = SparseArray(2, -1, 0.0f)(0 -> 12)


### PR DESCRIPTION
I tried for a while to fix this while staying within the scala collections framework.

The problem is, SparseArrays really aren't normal collections - it's the attempt to view them as such that causes a lot of the unneeded materialization.

When that wouldn't work, I looked at how Array itself was implemented.  It isn't part of the scala collections framework (of course), but has wrappers to help it fit therein.

I have not made said wrappers - they are a lot of extraneous boilerplate code with no current use, as far as I could tell.

Note: I have changed the signature for creating a sparse array.  I don't think anyone but me is currently using it outside spark itself (since it was only recently exposed at all, and that was for me), but it's possible there are ripple effects in some examples and salt modules.

Fixes #119 
