### PR TITLE
Implement a flatMap function for sparse arrays.

### DIFF
--- a/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
+++ b/src/main/scala/software/uncharted/salt/core/util/SparseArray.scala
@@ -148,7 +148,29 @@ class SparseArray[@specialized(Int, Long, Double) T: ClassTag] (_length: Int, _d
     result
   }
 
+  /** Transform this SparseArray according to the input function, concatenating transformed sequences.
+    *
+    * @param fcn The value transformation function
+    * @tparam U The output type
+    * @return A new sequence, with the values of this array transformed as specified
+    */
+  def flatMap[U: ClassTag] (fcn: T => Iterable[U]): Seq[U] = {
+    if (isMaterialized) {
+      denseStorage.map(_.flatMap(fcn)).get
+    } else if (fcn(_default).isEmpty) {
+      (0 until _length).flatMap { n =>
+        if (sparseStorage.contains(n)) {
+          fcn(sparseStorage(n))
+        } else {
+          None
+        }
+      }
+    } else {
+      seq.flatMap(fcn)
+    }
+  }
   /** Shorthand accessor for the first element of the array
+    *
     * @return The head element
     */
   def head: T = this(0)

--- a/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
+++ b/src/test/scala/software/uncharted/salt/core/util/SparseArraySpec.scala
@@ -223,6 +223,20 @@ class SparseArraySpec extends FunSpec {
       }
     }
 
+    describe("#flatMap") {
+      it("Should work fine on a dense array") {
+        val a = SparseArray(5, List[String](), 0.0f)(3 -> List("abc", "def"), 1 -> List("ghi", "jkl"))
+        assert(List("ghi", "jkl", "abc", "def") === a.flatMap(list => list).toList)
+      }
+      it("Should work fine on a sparse array") {
+        val a = SparseArray(5, List[String](), 1.0f)(3 -> List("abc", "def"), 1 -> List("ghi", "jkl"))
+        assert(List("ghi", "jkl", "abc", "def") === a.flatMap(list => list).toList)
+      }
+      it("Should include default values when the input function doesn't map them to empty iterables") {
+        val a = SparseArray(5, List[String](), 1.0f)(3 -> List("abc", "def"), 1 -> List("ghi", "jkl"))
+        assert(List("mno", "ghi", "jkl", "mno", "mno", "abc", "def", "mno", "mno") === a.flatMap(list => list :+ "mno").toList)
+      }
+    }
     describe("#mapWithIndex") {
       it("Should work fine on a dense array") {
         val a = SparseArray(3, 0, 0.0f)(0 -> 1, 2 -> 4)


### PR DESCRIPTION
As a result of this PR, the torque example in salt-examples should also change.

No rush for this PR though, it's not worth a version change on its own.  Save it until something else needs it.  Right now that example is the only thing that does, and it's hardly pressing.